### PR TITLE
repo: convert 'latest' to commit hash

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ import json
 import logging
 import task
 import schedule
+import repo
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -49,7 +50,9 @@ logging.basicConfig(level=logging.DEBUG)
 if __name__ == '__main__':
 
     ### testing code
-    test.modTbl()
+    # test.taskTest()
+    # test.repoTest()
+    # test.modTbl()
     # test.modMultiVals2()
     # test.modMultiVals()
     # test.qstnToTestPath()
@@ -64,6 +67,10 @@ if __name__ == '__main__':
         try:
             aTask = task.next()
             if len(aTask)>0:
+                ## If the value of gitHash is 'latest', get the latest commit
+                ## hash from GitHub
+                if aTask["gitHash"].lower()=="latest" and "gitBranch" in aTask:
+                    aTask["gitHash"] = repo.getGitHash(aTask["gitBranch"])
                 schedule.task(aTask)
             else:
                 logging.info("No pending tasks: sleeping")

--- a/repo.py
+++ b/repo.py
@@ -1,0 +1,61 @@
+###############################################################################
+# repo.py
+#
+###############################################################################
+from dotenv import load_dotenv
+load_dotenv()
+import git
+import os
+import logging
+
+###############################################################################
+# Support functions
+###############################################################################
+
+#######################################
+# Create a directory if it doesn't exist
+#######################################
+def mkDir(dir):
+    if not os.path.isdir(dir):
+        os.mkdir(dir)
+        logging.info(f"Created a directory: {dir}")
+
+    return dir
+
+#######################################
+# Get the repository directory
+#######################################
+def getRepoDir():
+    result = os.path.join(
+        mkDir(os.environ.get('dirScheduler')),
+        os.environ.get('repoName')
+    )
+    return mkDir(result)
+
+###############################################################################
+# Main logic
+###############################################################################
+def getGitHash(aBranch):
+    ## Get a directory for the CommonCore repo
+    dirRepo = getRepoDir()
+
+    ## Clone the remote repo locally if it doesn't already exist
+    theRepo = None
+    if not os.path.isdir(os.path.join(dirRepo, ".git")):
+        logging.info("Cloning a repo .....")
+        theRepo = git.Repo.clone_from(
+            os.environ.get('repoUrl'),
+            dirRepo,
+            branch=aBranch
+        )
+        ## Validate the repo
+        assert theRepo.active_branch.name == aBranch
+    else:
+        theRepo = git.Repo(dirRepo)
+        for remote in theRepo.remotes:
+            remote.fetch()
+        theRepo.git.checkout(aBranch)
+        theRepo.git.pull()
+        logging.debug(f"Pulled the latest code on {aBranch}")
+
+    return theRepo.active_branch.commit.hexsha

--- a/test.py
+++ b/test.py
@@ -14,6 +14,22 @@ import dbConn
 import schedule
 from datetime import datetime
 import json
+import repo
+import task
+
+def taskTest():
+    aTask = task.next()
+    print(f"before: {aTask}")
+    if len(aTask)>0:
+        if aTask["gitHash"].lower()=="latest" and "gitBranch" in aTask:
+            aTask["gitHash"] = repo.getGitHash(aTask["gitBranch"])
+    print(f"after: {aTask}")
+
+def repoTest():
+    # repo.getGitHash("dev")
+    # gitHash = repo.getGitHash("eb-dev")
+    gitHash = repo.getGitHash("jiraApp")
+    print (f"git hash: {gitHash}")
 
 def modMultiVals2():
     data = [{'status': True, 'result': 0, 'unq': 'QUES-12889'}, {'status': True, 'result': 0, 'unq': 'QUES-12888'}, {'status': True, 'result': 0, 'unq': 'QUES-12887'}, {'status': True, 'result': 0, 'unq': 'QUES-12886'}, {'status': True, 'result': 21, 'unq': 'QUES-12885'}, {'status': True, 'result': 14, 'unq': 'QUES-12884'}, {'status': True, 'result': 12, 'unq': 'QUES-12883'}, {'status': True, 'result': 18, 'unq': 'QUES-12882'}, {'status': True, 'result': 32, 'unq': 'QUES-12881'}, {'status': True, 'result': 25, 'unq': 'QUES-12880'}, {'status': False, 'result': 'QUES-12879 was not found in UDB', 'unq': 'QUES-12879'}, {'status': True, 'result': 52, 'unq': 'QUES-12878'}, {'status': True, 'result': 47, 'unq': 'QUES-12877'}, {'status': True, 'result': 43, 'unq': 'QUES-12876'}, {'status': True, 'result': 35, 'unq': 'QUES-12875'}, {'status': True, 'result': 41, 'unq': 'QUES-12874'}, {'status': True, 'result': 45, 'unq': 'QUES-12873'}, {'status': True, 'result': 41, 'unq': 'QUES-12872'}, {'status': False, 'result': 'QUES-12871 was not found in UDB', 'unq': 'QUES-12871'}, {'status': False, 'result': 'QUES-12870 was not found in UDB', 'unq': 'QUES-12870'}, {'status': True, 'result': 21, 'unq': 'QUES-12869'}, {'status': True, 'result': 24, 'unq': 'QUES-12868'}, {'status': True, 'result': 19, 'unq': 'QUES-12867'}, {'status': True, 'result': 30, 'unq': 'QUES-12866'}, {'status': True, 'result': 25, 'unq': 'QUES-12865'}, {'status': True, 'result': 28, 'unq': 'QUES-12864'}, {'status': True, 'result': 22, 'unq': 'QUES-12863'}, {'status': True, 'result': 23, 'unq': 'QUES-12862'}, {'status': True, 'result': 16, 'unq': 'QUES-12861'}, {'status': True, 'result': 20, 'unq': 'QUES-12860'}, {'status': True, 'result': 39, 'unq': 'QUES-12819'}, {'status': True, 'result': 48, 'unq': 'QUES-12818'}, {'status': True, 'result': 43, 'unq': 'QUES-12817'}, {'status': True, 'result': 55, 'unq': 'QUES-12816'}, {'status': True, 'result': 32, 'unq': 'QUES-12815'}, {'status': True, 'result': 32, 'unq': 'QUES-12814'}, {'status': True, 'result': 40, 'unq': 'QUES-12813'}, {'status': True, 'result': 45, 'unq': 'QUES-12812'}, {'status': True, 'result': 48, 'unq': 'QUES-12811'}, {'status': True, 'result': 38, 'unq': 'QUES-12810'}, {'status': True, 'result': 25, 'unq': 'QUES-12809'}, {'status': True, 'result': 23, 'unq': 'QUES-12808'}, {'status': True, 'result': 26, 'unq': 'QUES-12807'}, {'status': True, 'result': 23, 'unq': 'QUES-12806'}, {'status': True, 'result': 22, 'unq': 'QUES-12805'}, {'status': True, 'result': 32, 'unq': 'QUES-12804'}, {'status': True, 'result': 21, 'unq': 'QUES-12803'}, {'status': True, 'result': 35, 'unq': 'QUES-12802'}, {'status': True, 'result': 25, 'unq': 'QUES-12801'}, {'status': True, 'result': 28, 'unq': 'QUES-12800'}, {'status': True, 'result': 58, 'unq': 'QUES-12052'}, {'status': True, 'result': 22, 'unq': 'QUES-12051'}, {'status': True, 'result': 95, 'unq': 'QUES-12050'}, {'status': True, 'result': 73, 'unq': 'QUES-12049'}, {'status': True, 'result': 67, 'unq': 'QUES-12048'}, {'status': True, 'result': 88, 'unq': 'QUES-12047'}, {'status': True, 'result': 81, 'unq': 'QUES-12046'}, {'status': True, 'result': 28, 'unq': 'QUES-12045'}, {'status': True, 'result': 74, 'unq': 'QUES-12044'}, {'status': True, 'result': 93, 'unq': 'QUES-12043'}, {'status': True, 'result': 72, 'unq': 'QUES-12042'}, {'status': True, 'result': 56, 'unq': 'QUES-12041'}, {'status': True, 'result': 56, 'unq': 'QUES-12040'}, {'status': True, 'result': 67, 'unq': 'QUES-12039'}, {'status': True, 'result': 58, 'unq': 'QUES-12038'}, {'status': True, 'result': 62, 'unq': 'QUES-12037'}, {'status': True, 'result': 66, 'unq': 'QUES-12036'}, {'status': True, 'result': 20, 'unq': 'QUES-12035'}, {'status': True, 'result': 59, 'unq': 'QUES-12034'}, {'status': True, 'result': 15, 'unq': 'QUES-12033'}, {'status': True, 'result': 311, 'unq': 'QUES-6019'}, {'status': True, 'result': 297, 'unq': 'QUES-6011'}]


### PR DESCRIPTION
If the value of the gitHash field is 'latest', get the actual commit hash from GitHub when adding paths in the testPath table.