### PR TITLE
Handle multi-ref paths based on the fixMultiRefs setting in env

### DIFF
--- a/test_schedule.py
+++ b/test_schedule.py
@@ -126,7 +126,7 @@ def qstnsToTestPath():
     print("rslt")
     print(rslt)
 
-def failMultiRefs():
+def handleMultiRefs():
     data = [
         {
             'question_id': 56159,
@@ -147,13 +147,21 @@ def failMultiRefs():
             'msg': ""
         }
     ]
-    schedule.failMultiRefs(data)
+    schedule.handleMultiRefs(data)
     print(data)
 
+def fixMultiRefs():
+    pathIds = [42]
+    schedule.fixMultiRefs(pathIds)
+
+def fixMultiRefsQ():
+    print ("fixMultiRefsQ: {}".format(schedule.fixMultiRefsQ()))
 
 if __name__ == '__main__':
-    runTask()
-    # failMultiRefs()
+    handleMultiRefs()
+    # fixMultiRefsQ()
+    # fixMultiRefs()
+    # runTask()
     # qstnsToTestPath()
     # processReq2()
     # handleSchedule()


### PR DESCRIPTION
 If the setting is True, keep the latest ref and set the rest to refOld. If the setting is not True, multi-ref paths will have the fail status.